### PR TITLE
Hydra search path correction

### DIFF
--- a/sam2/__init__.py
+++ b/sam2/__init__.py
@@ -8,4 +8,4 @@ from hydra import initialize_config_module
 from hydra.core.global_hydra import GlobalHydra
 
 if not GlobalHydra.instance().is_initialized():
-    initialize_config_module("sam2", version_base="1.2")
+    initialize_config_module("sam2/configs/sam2.1", version_base="1.2")  # Modify the path to the config files folder

--- a/sam2/sam2_hiera_b+.yaml
+++ b/sam2/sam2_hiera_b+.yaml
@@ -1,1 +1,0 @@
-configs/sam2/sam2_hiera_b+.yaml

--- a/sam2/sam2_hiera_l.yaml
+++ b/sam2/sam2_hiera_l.yaml
@@ -1,1 +1,0 @@
-configs/sam2/sam2_hiera_l.yaml

--- a/sam2/sam2_hiera_s.yaml
+++ b/sam2/sam2_hiera_s.yaml
@@ -1,1 +1,0 @@
-configs/sam2/sam2_hiera_s.yaml

--- a/sam2/sam2_hiera_t.yaml
+++ b/sam2/sam2_hiera_t.yaml
@@ -1,1 +1,0 @@
-configs/sam2/sam2_hiera_t.yaml


### PR DESCRIPTION
By modifying the `Hydra search path` we avoid errors raised during the composition such as:
```python
hydra.errors.MissingConfigException: Cannot find primary config '/app/sam2/configs/sam2.1/sam2.1_hiera_t.yaml'. Check that it's in your config search path.
```

This way, the copy of the configurations in the main directory is no longer needed because we pick them directly from the configs directory.